### PR TITLE
Submodules support

### DIFF
--- a/modules/bg_controller/templates/pr-created-buildspec-source.yml.tpl
+++ b/modules/bg_controller/templates/pr-created-buildspec-source.yml.tpl
@@ -5,7 +5,6 @@ env:
   parameter-store:
     BB_USER: "/app/bb_user"  
     BB_PASS: "/app/bb_app_pass"
-    BB_KEY: "/app/bb_key"
     CONSUL_URL: "/infra/consul_url"
     CONSUL_HTTP_TOKEN: "/infra/${app_name}-${env_type}/consul_http_token"
 
@@ -20,6 +19,11 @@ phases:
           # "codepipeline user is a faceless user that have a ssh keys for sub module flow, the key is store in /app/bb_key ssm parameter."
           #
           echo "Project uses git submodules"
+          BB_KEY=$(aws ssm get-parameter --name "/app/bb_key" \
+          --with-decryption \
+          --output text \
+          --query Parameter.Value)
+
           mkdir -p ~/.ssh                     # "Ensure the .ssh directory exists"
           echo "$BB_KEY" > ~/.ssh/id_rsa      # "Save the codepipeline user's private key"
           chmod 600 ~/.ssh/id_rsa             # "Adjust the private key permissions (avoids a critical error)"

--- a/modules/merge_waiter/main.tf
+++ b/modules/merge_waiter/main.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_function" "merge_waiter" {
   function_name = "${var.app_name}-${var.env_type}-merge-waiter"
   role          = aws_iam_role.merge_waiter.arn
   handler       = "merge_waiter.handler"
-  runtime       = "nodejs14.x"
+  runtime       = "nodejs16.x"
   timeout       = 180
   source_code_hash = filebase64sha256("${path.module}/lambda/lambda.zip")
   environment {


### PR DESCRIPTION
This PR solves the issue for projects that uses gitmodules (git submodules) in their repositories.
We've created a faceless user in bitbucket and using his keys to pull (via ssh) repositories which have submodules.
Codepipeline doesn't have out-of-the-box solution for that (only for https) but in that base we need to change the way customers works for their repositories.

I didn't add the BB_KEY parameter via  parameter-store: because it will not be backward compatible.
if it will be added to "parameter-store" the pipeline will try to bring the value from  SSM and immediately fail because the parameter is doesn't exist in previously created accounts.
Thats the reason we're using aws cli in case .gitmodules exist to bring the parameters from SSM.