### PR TITLE
fix pattern of source branch trigger

### DIFF
--- a/modules/bg_controller/main.tf
+++ b/modules/bg_controller/main.tf
@@ -20,7 +20,7 @@ resource "aws_codebuild_webhook" "pr_flow_hook_webhook" {
 
     filter {
       type    = var.pipeline_type == "dev" ? "HEAD_REF" : "BASE_REF"
-      pattern = var.trigger_branch
+      pattern = "^refs/heads/${var.trigger_branch}$"
     }
 
     filter {
@@ -42,7 +42,7 @@ resource "aws_codebuild_webhook" "merge_flow_hook_webhook" {
 
     filter {
       type    = "BASE_REF"
-      pattern = var.trigger_branch
+      pattern = "^refs/heads/${var.trigger_branch}$"
     }
 
     filter {
@@ -69,7 +69,7 @@ resource "aws_codebuild_webhook" "merge_dev_flow_hook_webhook" {
 
     filter {
       type    = "FILE_PATH"
-      pattern = var.path_pattern
+      pattern = "^refs/heads/${var.trigger_branch}$"
     }
   }
 }

--- a/modules/bg_controller/main.tf
+++ b/modules/bg_controller/main.tf
@@ -64,12 +64,12 @@ resource "aws_codebuild_webhook" "merge_dev_flow_hook_webhook" {
 
     filter {
       type    = "HEAD_REF"
-      pattern = var.trigger_branch
+      pattern = "^refs/heads/${var.trigger_branch}$"
     }
 
     filter {
       type    = "FILE_PATH"
-      pattern = "^refs/heads/${var.trigger_branch}$"
+      pattern = var.path_pattern
     }
   }
 }


### PR DESCRIPTION
Since Webhook uses regex, opening PR to ABCD_develop or develop both would cause a trigger, this fixes the pattern 